### PR TITLE
Fixed error with uuid

### DIFF
--- a/pixel-saver@deadalnix.me/metadata.json
+++ b/pixel-saver@deadalnix.me/metadata.json
@@ -1,5 +1,5 @@
 {
-	"uuid": "pixel-saver@jensti.local",
+	"uuid": "pixel-saver@deadalnix.me",
 	"name": "Pixel Saver fork",
 	"description": "Pixel Saver is designed to save pixel by fusing activity bar and title bar in a natural way, This is a fork from the original",
 	"url": "https://github.com/jenstimmerman/pixel-saver",


### PR DESCRIPTION
Invalid UUID caused this error:
```
ERROR: Could not load extension pixel-saver@deadalnix.me: Error: uuid "pixel-saver@jensti.local" from metadata.json does not match directory name "pixel-saver@deadalnix.me"
```